### PR TITLE
Due to Heroku DNS issues we have to use the www subdomain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   def ensure_domain
     if request.env['HTTP_HOST'] == 'hulkort.herokuapp.com'
-      redirect_to "http://hulkort.com", status: 301
+      redirect_to "http://www.hulkort.com", status: 301
     end
   end
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,7 +8,7 @@
 <p>
   Simply make a <code>POST</code> request to track your commits:
 </p>
-<pre>http://hulkort.com/api/commits/?api_key=<%= display_api_key %></pre>
+<pre>http://www.hulkort.com/api/commits/?api_key=<%= display_api_key %></pre>
 <% unless current_user.present? %>
   <p>
     This is an example! Please <%= link_to "sign in", sign_in_path %> to see your personal URL and API key.
@@ -24,7 +24,7 @@
 mkdir ~/development/git-hooks
 cd ~/development/git-hooks
 echo '#!/bin/bash' >> post-commit
-echo 'curl -d "api_key=<%= display_api_key %>" http://hulkort.com/api/commits' >> post-commit
+echo 'curl -d "api_key=<%= display_api_key %>" http://www.hulkort.com/api/commits' >> post-commit
 
 <span># Set permissions so it can be executed</span>
 chmod 755 post-commit

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Hulkort::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.action_mailer.default_url_options = { :host => 'hulkort.com' }
+  config.action_mailer.default_url_options = { :host => 'www.hulkort.com' }
 
   config.eager_load = true
 end

--- a/features/step_definitions/hulkort_steps.rb
+++ b/features/step_definitions/hulkort_steps.rb
@@ -16,7 +16,7 @@ Given /^I have (\d+) commits?$/ do |number|
 end
 
 Then /^I should see my ping URL$/ do
-  page.should have_content("http://hulkort.com/api/commits/?api_key=" + @current_user.api_key)
+  page.should have_content("http://www.hulkort.com/api/commits/?api_key=" + @current_user.api_key)
 end
 
 Then /^I should see a list containing my commits$/ do

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond %{HTTP_HOST} ^hulkort\.com$ [NC]
+RewriteRule ^(.*)$ http://www.hulkort.com/$1 [R=301,L]


### PR DESCRIPTION
Everybody has to update their hook :-(

Btw. the install instructions did not work for me anymore, the linked `post-commit` file was not present in an example repository after running `git init`. Does this still work for you, @tombu ?
